### PR TITLE
Remove duplicate includes

### DIFF
--- a/Analysis/bin/BackgroundEstimate.cc
+++ b/Analysis/bin/BackgroundEstimate.cc
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <fstream>
 #include <array>
-#include <iostream>
 #include <string>
 #include <cstdlib>
 // #include <cmath>

--- a/Analysis/bin/CombineDatacards/CombineDatacards.cc
+++ b/Analysis/bin/CombineDatacards/CombineDatacards.cc
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <fstream>
 #include <array>
-#include <iostream>
 #include <string>
 #include <cstdlib>
 #include <iomanip>

--- a/Analysis/bin/datacardWork/MakeDatacards.cc
+++ b/Analysis/bin/datacardWork/MakeDatacards.cc
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <fstream>
 #include <array>
-#include <iostream>
 #include <string>
 #include <cstdlib>
 #include <iomanip>

--- a/Analysis/src/Channel.cc
+++ b/Analysis/src/Channel.cc
@@ -5,7 +5,6 @@
 #include "TStyle.h"
 #include "TH1.h"
 #include "TAxis.h"
-#include "TStyle.h"
 #include <iomanip>
 #include <iostream>
 #include <algorithm>

--- a/Analysis/src/FitEstimator.cc
+++ b/Analysis/src/FitEstimator.cc
@@ -12,15 +12,12 @@
 #include <sstream>
 #include <fstream>
 #include <array>
-#include <iostream>
 #include <string>
 #include "CMSAnalysis/Analysis/interface/HistVariable.hh"
 #include <cstdlib>
 #include "TH2.h"
 #include "TH2F.h"
-#include "TFile.h"
 #include <memory>
-#include "CMSAnalysis/Analysis/interface/HistVariable.hh"
 
 TH1* FitEstimator::getFitHist(HistVariable histType) const {
     return fitInput->getHist(histType);

--- a/Analysis/src/MultiSystematic.cc
+++ b/Analysis/src/MultiSystematic.cc
@@ -6,7 +6,6 @@
 #include "TStyle.h"
 #include "TH1.h"
 #include "TAxis.h"
-#include "TStyle.h"
 #include <iomanip>
 #include <iostream>
 #include <algorithm>

--- a/Analysis/src/PlotFormatter.cc
+++ b/Analysis/src/PlotFormatter.cc
@@ -15,8 +15,6 @@
 #include "TFile.h"
 #include "TFrame.h"
 #include "TStyle.h"
-#include "TPad.h"
-#include "TPad.h"
 #include "TLatex.h"
 #include "TLegend.h"
 #include "TLine.h"

--- a/Analysis/src/RateSystematic.cc
+++ b/Analysis/src/RateSystematic.cc
@@ -6,7 +6,6 @@
 #include "TStyle.h"
 #include "TH1.h"
 #include "TAxis.h"
-#include "TStyle.h"
 #include <iomanip>
 #include <iostream>
 #include <algorithm>

--- a/Analysis/src/RootFileInput.cc
+++ b/Analysis/src/RootFileInput.cc
@@ -5,7 +5,6 @@
 #include <iostream>
 #include "TH2.h"
 #include "TH2F.h"
-#include "TFile.h"
 #include "TSystem.h"
 #include <memory>
 #include <string>

--- a/Analysis/src/ShapeSystematic.cc
+++ b/Analysis/src/ShapeSystematic.cc
@@ -6,7 +6,6 @@
 #include "TStyle.h"
 #include "TH1.h"
 #include "TAxis.h"
-#include "TStyle.h"
 #include <iomanip>
 #include <iostream>
 #include <algorithm>

--- a/Analysis/src/Systematic.cc
+++ b/Analysis/src/Systematic.cc
@@ -6,7 +6,6 @@
 #include "TStyle.h"
 #include "TH1.h"
 #include "TAxis.h"
-#include "TStyle.h"
 #include <iomanip>
 #include <iostream>
 #include <algorithm>

--- a/Analysis/src/WindowEstimator.cc
+++ b/Analysis/src/WindowEstimator.cc
@@ -12,11 +12,9 @@
 #include "CMSAnalysis/Analysis/interface/HistVariable.hh"
 #include <fstream>
 #include <array>
-#include <iostream>
 #include <string>
 #include <cstdlib>
 #include "CMSAnalysis/Analysis/interface/WindowEstimator.hh"
-#include "CMSAnalysis/Analysis/interface/HistVariable.hh"
 
 
 double WindowEstimator::getExpectedYield(const SingleProcess* process, HistVariable dataType, double luminosity) const

--- a/DataCollection/bin/BackgroundEstimate.cc
+++ b/DataCollection/bin/BackgroundEstimate.cc
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <fstream>
 #include <array>
-#include <iostream>
 #include <string>
 #include <cstdlib>
 #include "TH2.h"

--- a/DataCollection/bin/FitGetter.cc
+++ b/DataCollection/bin/FitGetter.cc
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <fstream>
 #include <array>
-#include <iostream>
 #include <string>
 #include <cstdlib>
 #include "TH2.h"

--- a/Modules/src/JSONScaleFactor.cc
+++ b/Modules/src/JSONScaleFactor.cc
@@ -9,7 +9,6 @@
 #include "CMSAnalysis/Utility/interface/Utility.hh"
 #include "CMSAnalysis/Modules/interface/EventInput.hh"
 #include "EventFilter/Utilities/interface/json.h"
-#include "CMSAnalysis/Utility/interface/Utility.hh"
 #include "TH1.h"
 #include "TH2.h"
 #include "TCanvas.h"

--- a/Plans/src/HiggsBackgroundPlan.cc
+++ b/Plans/src/HiggsBackgroundPlan.cc
@@ -31,7 +31,6 @@
 #include "CMSAnalysis/Filters/interface/TriggerCut.hh"
 #include "CMSAnalysis/Histograms/interface/TwoInvariantMassesHist.hh"
 #include "CMSAnalysis/Histograms/interface/HistogramPrototype2DProjection.hh"
-#include "CMSAnalysis/Histograms/interface/METHist.hh"
 #include "CMSAnalysis/Filters/interface/BJetCut.hh"
 #include "CMSAnalysis/Modules/interface/EventModule.hh"
 #include "CMSAnalysis/Filters/interface/RunFilter.hh"

--- a/Plans/src/HiggsInvariantMassPlan.cc
+++ b/Plans/src/HiggsInvariantMassPlan.cc
@@ -28,7 +28,6 @@
 #include "CMSAnalysis/Modules/interface/HPlusPlusEfficiency.hh"
 #include "CMSAnalysis/Filters/interface/TriggerCut.hh"
 #include "CMSAnalysis/Histograms/interface/TwoInvariantMassesHist.hh"
-#include "CMSAnalysis/Histograms/interface/METHist.hh"
 #include "CMSAnalysis/Filters/interface/BJetFilter.hh"
 #include "CMSAnalysis/Modules/interface/EventModule.hh"
 #include "CMSAnalysis/Modules/interface/RecoGenSimComparisonModule.hh"

--- a/Plans/src/MuonPlan.cc
+++ b/Plans/src/MuonPlan.cc
@@ -28,7 +28,6 @@
 #include "CMSAnalysis/Modules/interface/HPlusPlusEfficiency.hh"
 #include "CMSAnalysis/Filters/interface/TriggerCut.hh"
 #include "CMSAnalysis/Histograms/interface/TwoInvariantMassesHist.hh"
-#include "CMSAnalysis/Histograms/interface/METHist.hh"
 #include "CMSAnalysis/Filters/interface/BJetFilter.hh"
 #include "CMSAnalysis/Modules/interface/EventModule.hh"
 #include "CMSAnalysis/Filters/interface/MuonSelector.hh"

--- a/Utility/src/Utility.cc
+++ b/Utility/src/Utility.cc
@@ -3,7 +3,6 @@
 #include <vector>
 #include <string>
 #include <cmath>
-#include <vector>
 #include <iostream>
 #include <numeric>
 


### PR DESCRIPTION
## Summary
- clean up duplicate `#include` lines across a few source files

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError in DataCollection/bin/addADDfiles.py)*

------
https://chatgpt.com/codex/tasks/task_b_6854e65bcc0c832ea82de766a956a5ca